### PR TITLE
Fix materialized tools displaying incorrectly 3rd person

### DIFF
--- a/src/main/resources/assets/materialisation/models/item/materialised_axe.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_axe.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_axe_handle",
     "layer1": "materialisation:item/materialised_axe_head"

--- a/src/main/resources/assets/materialisation/models/item/materialised_axe_both.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_axe_both.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_axe_handle_bright",
     "layer1": "materialisation:item/materialised_axe_head_bright"

--- a/src/main/resources/assets/materialisation/models/item/materialised_axe_only_handle.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_axe_only_handle.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_axe_handle_bright",
     "layer1": "materialisation:item/materialised_axe_head"

--- a/src/main/resources/assets/materialisation/models/item/materialised_axe_only_head.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_axe_only_head.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_axe_handle",
     "layer1": "materialisation:item/materialised_axe_head_bright"

--- a/src/main/resources/assets/materialisation/models/item/materialised_hammer.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_hammer.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_hammer_handle",
     "layer1": "materialisation:item/materialised_hammer_head"

--- a/src/main/resources/assets/materialisation/models/item/materialised_hammer_both.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_hammer_both.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_hammer_handle_bright",
     "layer1": "materialisation:item/materialised_hammer_head_bright"

--- a/src/main/resources/assets/materialisation/models/item/materialised_hammer_only_handle.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_hammer_only_handle.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_hammer_handle_bright",
     "layer1": "materialisation:item/materialised_hammer_head"

--- a/src/main/resources/assets/materialisation/models/item/materialised_hammer_only_head.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_hammer_only_head.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_hammer_handle",
     "layer1": "materialisation:item/materialised_hammer_head_bright"

--- a/src/main/resources/assets/materialisation/models/item/materialised_megaaxe.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_megaaxe.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_axe_handle",
     "layer1": "materialisation:item/materialised_megaaxe_head"

--- a/src/main/resources/assets/materialisation/models/item/materialised_megaaxe_both.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_megaaxe_both.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_axe_handle_bright",
     "layer1": "materialisation:item/materialised_megaaxe_head_bright"

--- a/src/main/resources/assets/materialisation/models/item/materialised_megaaxe_only_handle.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_megaaxe_only_handle.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_axe_handle_bright",
     "layer1": "materialisation:item/materialised_megaaxe_head"

--- a/src/main/resources/assets/materialisation/models/item/materialised_megaaxe_only_head.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_megaaxe_only_head.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_axe_handle",
     "layer1": "materialisation:item/materialised_megaaxe_head_bright"

--- a/src/main/resources/assets/materialisation/models/item/materialised_pickaxe.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_pickaxe.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_pickaxe_handle",
     "layer1": "materialisation:item/materialised_pickaxe_head"

--- a/src/main/resources/assets/materialisation/models/item/materialised_pickaxe_both.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_pickaxe_both.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_pickaxe_handle_bright",
     "layer1": "materialisation:item/materialised_pickaxe_head_bright"

--- a/src/main/resources/assets/materialisation/models/item/materialised_pickaxe_only_handle.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_pickaxe_only_handle.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_pickaxe_handle_bright",
     "layer1": "materialisation:item/materialised_pickaxe_head"

--- a/src/main/resources/assets/materialisation/models/item/materialised_pickaxe_only_head.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_pickaxe_only_head.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_pickaxe_handle",
     "layer1": "materialisation:item/materialised_pickaxe_head_bright"

--- a/src/main/resources/assets/materialisation/models/item/materialised_shovel.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_shovel.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_shovel_handle",
     "layer1": "materialisation:item/materialised_shovel_head"

--- a/src/main/resources/assets/materialisation/models/item/materialised_shovel_both.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_shovel_both.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_shovel_handle_bright",
     "layer1": "materialisation:item/materialised_shovel_head_bright"

--- a/src/main/resources/assets/materialisation/models/item/materialised_shovel_only_handle.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_shovel_only_handle.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_shovel_handle_bright",
     "layer1": "materialisation:item/materialised_shovel_head"

--- a/src/main/resources/assets/materialisation/models/item/materialised_shovel_only_head.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_shovel_only_head.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_shovel_handle",
     "layer1": "materialisation:item/materialised_shovel_head_bright"

--- a/src/main/resources/assets/materialisation/models/item/materialised_sword.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_sword.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_sword_handle",
     "layer1": "materialisation:item/materialised_sword_blade"

--- a/src/main/resources/assets/materialisation/models/item/materialised_sword_both.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_sword_both.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_sword_handle_bright",
     "layer1": "materialisation:item/materialised_sword_blade_bright"

--- a/src/main/resources/assets/materialisation/models/item/materialised_sword_only_handle.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_sword_only_handle.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_sword_handle_bright",
     "layer1": "materialisation:item/materialised_sword_blade"

--- a/src/main/resources/assets/materialisation/models/item/materialised_sword_only_head.json
+++ b/src/main/resources/assets/materialisation/models/item/materialised_sword_only_head.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "materialisation:item/materialised_sword_handle",
     "layer1": "materialisation:item/materialised_sword_blade_bright"


### PR DESCRIPTION
Materialized tools were displaying as normal items, not tools when held in third person because the "parent" field in their modelname.json files was set to "item/generated" instead of "item/handheld".