### PR TITLE
Improve validation in Material Override creation menu

### DIFF
--- a/src/main/java/me/shedaniel/materialisation/modmenu/MaterialisationCreateOverrideScreen.java
+++ b/src/main/java/me/shedaniel/materialisation/modmenu/MaterialisationCreateOverrideScreen.java
@@ -14,8 +14,10 @@ import net.minecraft.text.TranslatableText;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 public class MaterialisationCreateOverrideScreen extends Screen {
+    public static final Pattern HEX_COLOR = Pattern.compile("^#([A-Fa-f0-9]{8})$");
     private MaterialisationMaterialsScreen og;
     private Screen parent;
     private PartMaterial partMaterial;
@@ -56,7 +58,7 @@ public class MaterialisationCreateOverrideScreen extends Screen {
             entries = listWidget.children();
         } else {
             entries.add(new BooleanEditEntry("enabled", true));
-            entries.add(new StringEditEntry("toolColor", "#" + toStringColor(partMaterial.getToolColor())));
+            entries.add(new StringEditEntry("toolColor", "#" + toStringColor(partMaterial.getToolColor()), HEX_COLOR));
             entries.add(new IntEditEntry("toolDurability", partMaterial.getToolDurability()));
             entries.add(new IntEditEntry("miningLevel", partMaterial.getMiningLevel()));
             entries.add(new IntEditEntry("enchantability", partMaterial.getEnchantability()));

--- a/src/main/java/me/shedaniel/materialisation/modmenu/MaterialisationCreateOverrideScreen.java
+++ b/src/main/java/me/shedaniel/materialisation/modmenu/MaterialisationCreateOverrideScreen.java
@@ -17,7 +17,7 @@ import java.util.Locale;
 import java.util.regex.Pattern;
 
 public class MaterialisationCreateOverrideScreen extends Screen {
-    public static final Pattern HEX_COLOR = Pattern.compile("^#([A-Fa-f0-9]{8})$");
+    public static final Pattern HEX_COLOR = Pattern.compile("^#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$");
     private MaterialisationMaterialsScreen og;
     private Screen parent;
     private PartMaterial partMaterial;

--- a/src/main/java/me/shedaniel/materialisation/modmenu/entries/DoubleEditEntry.java
+++ b/src/main/java/me/shedaniel/materialisation/modmenu/entries/DoubleEditEntry.java
@@ -9,6 +9,7 @@ import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.client.resource.language.I18n;
 
 import java.text.DecimalFormat;
+import java.text.ParsePosition;
 import java.util.List;
 
 public class DoubleEditEntry extends MaterialisationCreateOverrideListWidget.EditEntry {
@@ -17,6 +18,7 @@ public class DoubleEditEntry extends MaterialisationCreateOverrideListWidget.Edi
     private TextFieldWidget buttonWidget;
     private ButtonWidget resetButton;
     private List<Element> widgets;
+    private ParsePosition parsePosition = new ParsePosition(0);
     private static final DecimalFormat DF = new DecimalFormat("#.##");
 
     public DoubleEditEntry(String s, double defaultValue) {
@@ -25,12 +27,7 @@ public class DoubleEditEntry extends MaterialisationCreateOverrideListWidget.Edi
         this.buttonWidget = new TextFieldWidget(MinecraftClient.getInstance().textRenderer, 0, 0, 150, 16, "") {
             @Override
             public void render(int int_1, int int_2, float float_1) {
-                try {
-                    double i = Double.valueOf(getText());
-                    setEditableColor(14737632);
-                } catch (NumberFormatException ex) {
-                    setEditableColor(16733525);
-                }
+                setEditableColor(isValid() ? 0xe0e0e0 : 0xff5555);
                 super.render(int_1, int_2, float_1);
             }
         };
@@ -70,22 +67,20 @@ public class DoubleEditEntry extends MaterialisationCreateOverrideListWidget.Edi
 
     @Override
     public Double getValue() {
-        try {
-            double i = Double.valueOf(buttonWidget.getText());
-            return i;
-        } catch (NumberFormatException ex) {
-            return Double.valueOf(defaultValue);
+        parsePosition.setIndex(0);
+        Number value = DF.parse(buttonWidget.getText(), parsePosition);
+        if (parsePosition.getIndex() != 0) {
+            return value.doubleValue();
         }
+        return defaultValue;
     }
 
     @Override
     public boolean isValid() {
-        try {
-            double i = Double.valueOf(buttonWidget.getText());
-            return true;
-        } catch (NumberFormatException ex) {
-            return false;
-        }
+        parsePosition.setIndex(0);
+        String text = buttonWidget.getText();
+        DF.parse(text, parsePosition);
+        return parsePosition.getIndex() == text.length();
     }
 
     @Override

--- a/src/main/java/me/shedaniel/materialisation/modmenu/entries/StringEditEntry.java
+++ b/src/main/java/me/shedaniel/materialisation/modmenu/entries/StringEditEntry.java
@@ -9,21 +9,28 @@ import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.client.resource.language.I18n;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class StringEditEntry extends MaterialisationCreateOverrideListWidget.EditEntry {
 
     private String defaultValue;
+    private Pattern validation;
     private TextFieldWidget buttonWidget;
     private ButtonWidget resetButton;
     private List<Element> widgets;
 
     public StringEditEntry(String s, String defaultValue) {
+        this(s, defaultValue, null);
+    }
+
+    public StringEditEntry(String s, String defaultValue, Pattern validation) {
         super(s);
         this.defaultValue = defaultValue;
+        this.validation = validation;
         this.buttonWidget = new TextFieldWidget(MinecraftClient.getInstance().textRenderer, 0, 0, 150, 16, "") {
             @Override
             public void render(int int_1, int int_2, float float_1) {
-                setEditableColor(14737632);
+                setEditableColor(isValid() ? 0xe0e0e0 : 0xff5555);
                 super.render(int_1, int_2, float_1);
             }
         };
@@ -62,13 +69,13 @@ public class StringEditEntry extends MaterialisationCreateOverrideListWidget.Edi
     }
 
     @Override
-    public Object getValue() {
+    public String getValue() {
         return buttonWidget.getText();
     }
 
     @Override
     public boolean isValid() {
-        return true;
+        return validation == null || validation.matcher(getValue()).matches();
     }
 
     @Override


### PR DESCRIPTION
This PR brings 2 changes that I thought would be helpful.
First, a fix to the `DoubleEditEntry`'s parsing code. Some locales (like French) use different decimal separators such as the comma. As such, the DecimalFormat fills the inputs with numbers that cannot be parsed back by `Double.parseDouble`. This PR fixes the issue by parsing the numbers through the DecimalFormat.
Second, the StringEditEntry has been modified to allow for RegEx validation. I used this functionality to validate the hex color input more effectively. The tool color field now only accepts valid hex numbers with 3, 6 or 8 digits.