### PR TITLE
Set missing mining level for diamond

### DIFF
--- a/src/main/java/me/shedaniel/materialisation/materials/DefaultMaterials.java
+++ b/src/main/java/me/shedaniel/materialisation/materials/DefaultMaterials.java
@@ -57,7 +57,7 @@ public class DefaultMaterials implements DefaultMaterialSupplier {
                 .aIngr(fromItem(Items.DIAMOND), 2)
                 .aIngr(fromItem(Items.DIAMOND_BLOCK), 18)
                 .autoTex()
-                .wAtta(3).setFullAmount(250).setBright(true).setToolSpeed(9f).wDuraMulti(0.8f).wSpeedMulti(1.0f).wColor(0xff68e8d9).setToolDurability(2031);
+                .wAtta(3).setFullAmount(250).setBright(true).setToolSpeed(9f).wDuraMulti(0.8f).wSpeedMulti(1.0f).wColor(0xff68e8d9).setToolDurability(2031).setMiningLevel(3);
     }
     
     @Override


### PR DESCRIPTION
The material constructor for diamond does not call `.setMiningLevel()`.

In-game, this means that diamond pickaxes do not successfully drop the materials they are supposed to drop.

![Screenshot](https://i.imgur.com/CDrW7nC.png)